### PR TITLE
Fixed pens not drawing if isShown was false

### DIFF
--- a/Assets/QvPen/Runtime/UdonScript/UI/QvPen_ShowOrHideButton.cs
+++ b/Assets/QvPen/Runtime/UdonScript/UI/QvPen_ShowOrHideButton.cs
@@ -18,7 +18,16 @@ namespace QvPen.UdonScript.UI
         [SerializeField]
         private GameObject displayObjectOff;
 
-        private void Start() => UpdateActivity();
+        private void Start()
+        {
+            if (!isShown)
+                // if isShown is false, flip it to true and run UpdateActivity in 5 frames
+                // doing this on the next frame, appears to make the pens no longer draw.
+            {
+                isShown = true;
+                SendCustomEventDelayedFrames(nameof(OffOnStart),5);
+            }
+        }
 
         public override void Interact()
         {
@@ -36,6 +45,13 @@ namespace QvPen.UdonScript.UI
             foreach (var go in gameObjects)
                 if (go)
                     go.SetActive(isShown);
+        }
+        
+        public void OffOnStart()
+        // proxy to flip isShown on start and to run UpdateActivity without havingto make it public
+        {
+            isShown = false;
+            UpdateActivity();
         }
     }
 }

--- a/Assets/QvPen/Runtime/UdonScript/UI/QvPen_ShowOrHideButton.cs
+++ b/Assets/QvPen/Runtime/UdonScript/UI/QvPen_ShowOrHideButton.cs
@@ -7,14 +7,18 @@ namespace QvPen.UdonScript.UI
     [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
     public class QvPen_ShowOrHideButton : UdonSharpBehaviour
     {
+        [Tooltip("The list of objects this turns On/Off.")]
         [SerializeField]
         private GameObject[] gameObjects = { };
 
+        [Tooltip("The default state of the pens when the world starts.\nThe pens will start on when this is true, and they will start off when this is false.\n\nThis should be used to toggle the pens off instead of turning them off in the Hierarchy!!")]
         [SerializeField]
         private bool isShown = true;
 
+        [Tooltip("The object that is used to indicate that the pens are On.")]
         [SerializeField]
         private GameObject displayObjectOn;
+        [Tooltip("The object that is used to indicate that the pens are Off.")]
         [SerializeField]
         private GameObject displayObjectOff;
 


### PR DESCRIPTION
The pens wouldn't draw if they were off on Start.

They also didn't work if toggled off on the next frame, so I chose to turn them off in 5 frames instead.