### PR TITLE
Fix for PC Line Renderer shader returns color in wrong Color Space

### DIFF
--- a/Assets/QvPen/Shader/rounded_trail_for_qv_pen.shader
+++ b/Assets/QvPen/Shader/rounded_trail_for_qv_pen.shader
@@ -137,7 +137,11 @@ Shader "QvPen/rounded_trail_for_qv_pen"
 			{
 				const float l = length(i.uv);
 				clip(0.5 - min(i.d, l));
+				#if UNITY_COLORSPACE_GAMMA
+				return float4(i.color.rgb, 1);
+				#else
 				return float4(GammaToLinearSpace(i.color.rgb), 1);
+				#endif
 			}
 			ENDCG
 		}

--- a/Assets/QvPen/Shader/rounded_trail_for_qv_pen.shader
+++ b/Assets/QvPen/Shader/rounded_trail_for_qv_pen.shader
@@ -69,7 +69,7 @@ Shader "QvPen/rounded_trail_for_qv_pen"
 
 			[maxvertexcount(10)]
 			void geom(triangle v2g IN[3], inout TriangleStream<g2f> stream) {
-				float dist = length(_WorldSpaceCameraPos - mul(unity_ObjectToWorld, IN[0].vertex));
+				const float dist = length(_WorldSpaceCameraPos - mul(unity_ObjectToWorld, IN[0].vertex));
 				if(dist < _NearClipDistance || dist > _FarClipDistance)
 					return;
 
@@ -135,7 +135,7 @@ Shader "QvPen/rounded_trail_for_qv_pen"
 			
 			fixed4 frag (g2f i) : SV_Target
 			{
-				float l = length(i.uv);
+				const float l = length(i.uv);
 				clip(0.5 - min(i.d, l));
 				return float4(GammaToLinearSpace(i.color.rgb), 1);
 			}

--- a/Assets/QvPen/Shader/rounded_trail_for_qv_pen.shader
+++ b/Assets/QvPen/Shader/rounded_trail_for_qv_pen.shader
@@ -137,7 +137,7 @@ Shader "QvPen/rounded_trail_for_qv_pen"
 			{
 				float l = length(i.uv);
 				clip(0.5 - min(i.d, l));
-				return float4(i.color.rgb, 1);
+				return float4(GammaToLinearSpace(i.color.rgb), 1);
 			}
 			ENDCG
 		}

--- a/Assets/QvPen/Shader/rounded_trail_for_qv_pen.shader
+++ b/Assets/QvPen/Shader/rounded_trail_for_qv_pen.shader
@@ -86,7 +86,7 @@ Shader "QvPen/rounded_trail_for_qv_pen"
 				float aspectRatio = -_ScreenParams.y / _ScreenParams.x;
 				d.x /= aspectRatio;
 				o.d = length(d);
-				if(length(d) < 0.000001) d = float2(1, 0);
+				if(o.d < 0.000001) d = float2(1, 0);
 				else d = normalize(d);
 				
 				float2 w = _Width;


### PR DESCRIPTION
The Line Renderer/Gradient(?) returns a color property always in Gamma space, but Linear space is recommended and mostly used in VRChat, so it should be converted if Linear space is configured in the project settings. Otherwise the colors are faded and not as bright as they should be and as configured by the user.

An example of the issue with `#8441A1` color:

> QVPen Color Gradient settings:
> ![image](https://github.com/ureishi/QvPen/assets/56228630/909ee256-9c35-4f0e-adec-8488d5c4ca88)

> Without fix `#BE8AD0`:
> ![image](https://github.com/ureishi/QvPen/assets/56228630/804baaf2-6733-4ed5-9c9a-94bdeef86a54)

> With fix `#8441A1`:
> ![image](https://github.com/ureishi/QvPen/assets/56228630/42f4802c-fcaf-45e8-916f-85868850b373)
