### PR TITLE
Fixed network spam on player join

### DIFF
--- a/Assets/QvPen/Runtime/UdonScript/QvPen_LateSync.cs
+++ b/Assets/QvPen/Runtime/UdonScript/QvPen_LateSync.cs
@@ -23,8 +23,8 @@ namespace QvPen.UdonScript
             if (master == null || player.playerId < master.playerId)
                 master = player;
 
-            if (VRCPlayerApi.GetPlayerCount() > 1 && !Networking.IsOwner(gameObject))
-                SendCustomNetworkEvent(NetworkEventTarget.Owner, nameof(StartSync));
+            if (VRCPlayerApi.GetPlayerCount() > 1 && Networking.IsOwner(gameObject))
+                StartSync();
         }
 
         public override void OnOwnershipTransferred(VRCPlayerApi player)


### PR DESCRIPTION
Fixes #17, making the pen's owner trigger sync himself, instead of everyone requesting it from him.