### PR TITLE
Fixed U# Assembly Definition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Auto detect text files and perform LF normalization
-* text=auto


### PR DESCRIPTION
The U# Assembly Definition file, Assets/QvPen/QvPen.asset , does not work properly on Windows.
It's caused by its CRLF newlines transformed from LF by git because of the .gitattributes file.
Fixed by removing .gitattributes .

It's a nuclear option, but it works, and also fixes all of the other annoyances of git showing me that i've allegedly modified a file, because it was resaved by Unity with LF, and it thinks the file should've had CRLF.

Like, really, you don't need CRLF on Windows - just use anything other than the Notepad to code. Heck, even Windows 10+ Notepad handles LF.