### PR TITLE
Tweaking dependencies to work with Unity 2022

### DIFF
--- a/Assets/QvPen/package.json
+++ b/Assets/QvPen/package.json
@@ -6,7 +6,7 @@
   "description": "VRChat World Pen.",
   "url": "https://github.com/ureishi/QvPen/releases/download/v3.2.9/net.ureishi.qvpen-3.2.9.zip",
   "dependencies": {
-    "com.unity.textmeshpro": "^2.1.4"
+    "com.unity.textmeshpro": "^2.1.4 || ^3.0.6"
   },
   "vpmDependencies": {
     "com.vrchat.udonsharp": "^1.1.8"


### PR DESCRIPTION
A warning occurs when importing QvPen into a Unity 2022 project as the VPM package, as shown in the image below.

![com.unity.textmeshpro (dependency): Version '^2.1.4' is invalid. Excepted a 'SemVer' compatible value.](https://github.com/ureishi/QvPen/assets/44661432/b6892ca3-6a52-4d7a-b276-b1262aa8fd4c)

Fortunately, this warning is ignorable and does not interfere with the VRChat world development, but I would like to improve it as it occurs every time I start Unity 2022.

The cause is a resolving fail in one of the dependent packages, TextMesh Pro. QvPen requires version ^2.1.4 of TextMesh Pro, but Unity 2022 requires a migration to 3.0. Since the latest version of the current 3.0 family is 3.0.6, this pull request intends to include this in the acceptable range to work properly with Unity 2022.

P.S. I checked the QvPen in a world created with Unity 2022. I didn't test all the features, but the basic features work fine.