### PR TITLE
remove TMP from dependencies

### DIFF
--- a/Assets/QvPen/package.json
+++ b/Assets/QvPen/package.json
@@ -4,9 +4,6 @@
   "version": "3.2.10",
   "description": "VRChat World Pen.",
   "url": "https://github.com/ureishi/QvPen/releases/download/v3.2.10/net.ureishi.qvpen-3.2.10.zip",
-  "dependencies": {
-    "com.unity.textmeshpro": "^2.1.4"
-  },
   "vpmDependencies": {
     "com.vrchat.worlds": "^3.4.0"
   },


### PR DESCRIPTION
since major version of TMP is differ between 2019 and 2022, it's unable to declare compatible with both 2019 and 2022. so, remove TMP from dependencies and depends on TMP with transient dependency of VRCSDK worlds.

Fixes #22