### PR TITLE
Fix null reference exception when replaced all UI text components to TMPro

### DIFF
--- a/Assets/QvPen/Runtime/UdonScript/QvPen_EraserManager.cs
+++ b/Assets/QvPen/Runtime/UdonScript/QvPen_EraserManager.cs
@@ -75,7 +75,14 @@ namespace QvPen.UdonScript
             respawnButton.SetActive(true);
             inUseUI.SetActive(false);
 
-            textInUse.text = string.Empty;
+            if (textInUse)
+                textInUse.text = string.Empty;
+
+            if (textInUseTMP)
+                textInUseTMP.text = string.Empty;
+
+            if (textInUseTMPU)
+                textInUseTMPU.text = string.Empty;
         }
 
         public void ResetEraser() => eraser._Respawn();

--- a/Assets/QvPen/Runtime/UdonScript/QvPen_PenManager.cs
+++ b/Assets/QvPen/Runtime/UdonScript/QvPen_PenManager.cs
@@ -115,7 +115,14 @@ namespace QvPen.UdonScript
             if (inUseUI)
                 inUseUI.SetActive(false);
 
-            textInUse.text = string.Empty;
+            if (textInUse)
+                textInUse.text = string.Empty;
+
+            if (textInUseTMP)
+                textInUseTMP.text = string.Empty;
+
+            if (textInUseTMPU)
+                textInUseTMPU.text = string.Empty;
         }
 
         private PositionConstraint clearButtonPositionConstraint;


### PR DESCRIPTION
I have tried to migrate all text components in QvPen UI to TextMeshPro and find out it throws null reference exceptions when in use. After dig in I find out it does not check null reference in `EndUsing()` method, also it does not handle TMPro variants as well.

This PR fixes this issue.