### PR TITLE
Add opt-in double-click functionality to interact button

### DIFF
--- a/Assets/QvPen/Runtime/UdonScript/UI/QvPen_InteractButton.cs
+++ b/Assets/QvPen/Runtime/UdonScript/UI/QvPen_InteractButton.cs
@@ -27,9 +27,22 @@ namespace QvPen.Udon.UI
         private UdonSharpBehaviour[] udonSharpBehaviours = { };
         [SerializeField]
         private string customEventName = "Unnamed";
+        
+        [SerializeField]
+        private bool requireDoubleClick = false;
+        [SerializeField]
+        private float doubleClickDuration = 0.5f;
+        private bool _doubleClickAcceptable = false;
 
         public override void Interact()
         {
+            if (requireDoubleClick && !_doubleClickAcceptable)
+            {
+                _doubleClickAcceptable = true;
+                SendCustomEventDelayedSeconds(nameof(_DoubleClickTimeout), doubleClickDuration);
+                return;
+            }
+            
             if (!canUseEveryone)
             {
                 if (canUseInstanceOwner && !Networking.IsInstanceOwner)
@@ -54,6 +67,11 @@ namespace QvPen.Udon.UI
                 else
                     foreach (var udonSharpBehaviour in udonSharpBehaviours)
                         udonSharpBehaviour.SendCustomNetworkEvent(onlySendToOwner ? NetworkEventTarget.Owner : NetworkEventTarget.All, customEventName);
+        }
+
+        public void _DoubleClickTimeout()
+        {
+            _doubleClickAcceptable = false;
         }
     }
 }


### PR DESCRIPTION
#24 に関連して、特定のボタンを誤発動しにくくするためにダブルクリックを必要とする機能を `InteractButton` に追加しました。この機能はデフォルトで OFF で、ワールド開発者はプレハブのオーバーライドで任意に Clear ボタンなどに設定可能です (つまり、破壊的変更ではありません)。

![image](https://github.com/ureishi/QvPen/assets/60507815/ec8e6fd2-bac8-4092-ab27-2fa42760c60a)

**長押しでない理由**: 長押しとダブルクリックのどちらが誤発動に効果があるかは諸説あると思いますが、長押し (一定時間ずっと一定距離内で interact し続けているか) を判定するのは複雑なためです。